### PR TITLE
work on portable year-over-year content

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -200,8 +200,8 @@ workshop-registration:
 # "show" just means display on home page, "open" means people can register
 conference-registration:
   show: false
-  url: http://www.cvent.com/d/ybq5dx/4W
-  start-date: "2018-12-05"
+  url: ""
+  start-date: Null
   end-date: Null
   open: false
 
@@ -209,40 +209,43 @@ conference-registration:
 # Schedule events
 ##################
 
+# usually on the wiki
+social-activities-url: ""
+
 newcomer-dinner:
     show: false
     # entering the URL doubles as a "show more info" switch, too
-    signup-url: https://drive.google.com/open?id=1XQg7jRiI4YWaCwJo3GiTt98l7eBmXTAyHKoFkdgfJnI
-    transit-info: https://docs.google.com/document/d/1zThXYjzsnXN0V7f1U_iEzgy2pZJna0EMTg59GQJClac/edit
-    activities-info: https://drive.google.com/open?id=1UqZIAHg2qllhbHCsv4JRXkbNqJ1qGOht&usp=sharing
-    date: "2019-02-19"
+    signup-url: ""
+    transit-info: ""
+    activities-info: ""
+    date: ""
 
 game-night:
     show: false
-    url: https://wiki.code4lib.org/2019_Social_Activities#Game_Night.2C_Thursday.2C_February_21st
-    date: "2019-02-21"
-    time: "6:30PM - 9:30PM"
+    url: ""
+    date: ""
+    time: ""
 
 libtech-women:
     show: false
-    date: "2019-02-21"
-    time: "5:30PM - 7:30PM"
-    location: "2050 Lobby Bar, DoubleTree San José"
+    date: ""
+    time: ""
+    location: ""
     hashtag: libtechwomen
 
 reception:
     show: false
-    date: "2019-02-20"
+    date: ""
 
 karaoke-night:
     show: false
-    url: https://wiki.code4lib.org/2019_Social_Activities#Karaoke_Night.2C_Thursday.2C_February_21st
-    date: "2019-02-21"
-    time: "TBA"
+    url: ""
+    date: ""
+    time: ""
 
 self-event:
     show: false
-    url: https://docs.google.com/document/d/1VVfaRFpYwXyZfRI5hRTorIW4hSzu4yg13S-R-M-EGoE/edit
+    url: ""
 
 ###############
 # Volunteer
@@ -250,19 +253,19 @@ self-event:
 
 volunteer-committee:
   show: true
-  url: https://wiki.code4lib.org/Code4Lib_2020_Conference_Committees
+  url: "https://wiki.code4lib.org/Code4Lib_2020_Conference_Committees"
   end-date: "2020-01-18"
 
 volunteer-dutyoff:
   show: false
-  url: https://goo.gl/forms/2DkdbUUDSSOMi1f33
-  end-date: "2018-11-18"
+  url: "https://goo.gl/forms/2DkdbUUDSSOMi1f33"
+  end-date: ""
 
 # for volunteers during conference like MCs, mic-minders, etc.
 volunteer-onsite:
   show: false
-  url: https://wiki.code4lib.org/2019_Conference_Volunteers
-  end-date: "2019-02-22"
+  url: ""
+  end-date: ""
 
 ################
 # Scholarships
@@ -287,3 +290,10 @@ diversity-scholarship-applications:
 # show sponsors for diversity scholarships on general-info/scholarships
 diversity-scholarship-general-sponsors:
   show: true
+
+################
+# Other
+################
+
+quiet-room:
+    show: false

--- a/_data/examples/schedule.yml
+++ b/_data/examples/schedule.yml
@@ -62,6 +62,8 @@
   menu: day3-menus
   submenu: Morning
 
+# NOTE: first-timers page uses the link properties of the first events with
+# titles like "Breakout Sessions" and "Lightning Talks"
 # Breakouts
 - timeImg: 2.45.png
   title: Breakout Sessions 1

--- a/general-info/accessibility.html
+++ b/general-info/accessibility.html
@@ -6,8 +6,8 @@ active: Accessibility
 subnav:
 - name: 'Contact'
   url: '#contactus'
-#- name: 'Quiet Room'
-#  url: '#quietroom'
+- name: 'Quiet Room'
+  url: '#quietroom'
 - name: 'For Presenters'
   url: '#presenters'
 ---
@@ -23,7 +23,7 @@ subnav:
             <h2 id="contactus">Contact</h2>
             <p>Contact <a href="mailto:{{site.data.conf.accessibility-email}}">{{site.data.conf.accessibility-email}}</a> with any questions or concerns related to the conference's accessibility.</p>
 
-            {% comment %}
+            {% if site.data.conf.quiet-room.show %}
             <h2 id="quietroom">Quiet Room</h2>
             <p>
                From Tuesday to Friday a quiet room will be available at the conference hotel,
@@ -60,7 +60,10 @@ subnav:
                      so that all of you can find a bit of quiet.
                </li>
             </ul>
-            {% endcomment %}
+            {% else %}
+            {% comment %} remove from secondary nav (jQuery not yet on page) {% endcomment %}
+            <script>document.querySelector('.secondarynav a[href="#quietroom"]').parentElement.remove()</script>
+            {% endif %}
 
             <h2>Live Captioning</h2>
             <p>During the general conference, Code4Lib {{site.data.conf.year}} will feature live captioning.

--- a/general-info/first-timers.html
+++ b/general-info/first-timers.html
@@ -25,14 +25,27 @@ active: First Timers
         No one is an expert in everything, so don't worry that you don't know every single thing that is mentioned in the presentations.
       </p>
       <p>
-        Even if you don’t have a scheduled talk, there are two ways you can still share with other conference goers:
+        Even if you don’t have a scheduled talk, there are other ways you can share with other conference goers.
       </p>
-      <p>
-        <a href="https://wiki.code4lib.org/Code4Lib2019_Breakout_Sessions"><strong>Breakout sessions</strong></a> are facilitated unconference discussions about a particular topic. Some present on a project that is in progress to get other’s feedback, others talk about standards, formats, and tools of the trade. You can also have breakout sessions about big picture topics, or possibly get like minded folks together to start planning a local/regional code4lib community gathering.
-      </p>
-      <p>
-        <a href="https://wiki.code4lib.org/Code4Lib2019_Lightning_Talks"><strong>Lightning talks</strong></a> are five minute talks on a topic of the presenter’s choosing. The lightning talks are an opportunity to provide a platform for someone who is just getting started with public speaking, who wants to ask a question or invite people to help with a project, or for someone to boast about something they did or tell a short cautionary story. Some lighting talks tend to steal the show at the conference!
-      </p>
+
+      {% comment %} iterate over schedule to see if we have breakout/lightning
+      talk events & then use their links below {% endcomment %}
+      {% for event in site.data.schedule %}
+          {% if event.title contains 'Breakout Session' %}
+          <p>
+            <a href="{{ event.link }}"><strong>Breakout sessions</strong></a> are facilitated unconference discussions about a particular topic. Some present on a project that is in progress to get other’s feedback, others talk about standards, formats, and tools of the trade. You can also have breakout sessions about big picture topics, or possibly get like minded folks together to start planning a local/regional code4lib community gathering.
+          </p>
+          {% break %}
+          {% endif %}
+      {% endfor %}
+      {% for event in site.data.schedule %}
+          {% if event.title contains 'Lightning Talks' %}
+          <p>
+            <a href="{{ event.link }}"><strong>Lightning talks</strong></a> are five minute talks on a topic of the presenter’s choosing. The lightning talks are an opportunity to provide a platform for someone who is just getting started with public speaking, who wants to ask a question or invite people to help with a project, or for someone to boast about something they did or tell a short cautionary story. Some lighting talks tend to steal the show at the conference!
+          </p>
+          {% break %}
+          {% endif %}
+      {% endfor %}
       <p>
         Both lightning talks and breakout sessions signups take place at the conference. Signups are usually on a posterboard by the registration; specific details about signup times and places will be announced from the podium, as well as social media.
       <p>
@@ -50,12 +63,13 @@ active: First Timers
         The venue will provide lunch Wednesday and Thursday, as well as morning and afternoon break snacks Wednesday through Friday morning. Menus will be posted on the website soon. There will be caffeine.
       </p>
 
-
+      {% if site.data.conf.social-activities-url != '' %}
       <h2>Social Activities</h2>
       <p>
-        There's a lot going on outside of the sessions, and <a href="https://wiki.code4lib.org/2019_Social_Activities">this page has information about various gatherings, events, meals, etc.</a>
+        There's a lot going on outside of the sessions, and <a href="{{site.data.conf.social-activities-url}}">this page has information about various gatherings, events, meals, etc.</a>
         In addition, if you have any events that you’d like to organize, please feel free to add the event to the DIY Event Google Doc!
       </p>
+       {% endif %}
 
       {% if site.data.conf.newcomer-dinner.show %}
       <h3>Newcomer Dinner</h3>
@@ -83,7 +97,7 @@ active: First Timers
       <h2>Volunteering</h2>
       <p>
         A round of applause for everyone who has helped to plan the conference! So much of what goes into making this event possible each year happens through the tireless efforts of our community members.
-        The work isn't quite done yet, and we're still looking for <a href="https://wiki.code4lib.org/Code4Lib_2019_Conference_Committees#Onsite_Volunteer_Committee">volunteers for a few on-site tasks</a> -
+        The work isn't quite done yet, and we're still looking for <a href="{{ site.data.conf.volunteer-committee.url }}">volunteers for a few on-site tasks</a> -
         the Whatever Crew is always looking for more volunteers, if you’re not quite sure what you want to do, but still want to help with the conference.
       </p>
 
@@ -98,7 +112,7 @@ active: First Timers
       <p>
         There will be A LOT of information thrown at you in a short period of time at code4lib. You will be mentally exhausted before conference end.
         For reference, the majority of folks “hit the wall” around the afternoon of the second full day. If you need to take a break, do so.
-        Decompress outside the conference room, use <a href="{{ '/general-info/accessibility#quietroom' | relative_url }}">the quiet room</a>, or try a <a href="https://twitter.com/search?f=tweets&vertical=default&q=%23nap4lib&src=typd">#nap4lib</a>!
+        {% if site.data.conf.quiet-room.show %}You can decompress outside the conference hall in <a href="{{ '/general-info/accessibility#quietroom' | relative_url }}">the quiet room</a>.{% endif %} Try a <a href="https://twitter.com/search?f=tweets&vertical=default&q=%23nap4lib&src=typd">#nap4lib</a>!
         The talks are recorded, so you can catch up on anything you might have missed during your break.
       </p>
 


### PR DESCRIPTION
Related to #5. Pages to check:

- general-info/first-timers
- general-info/accessibility

Testing notes:

- first test as is, there should be no mention of quiet room on A11y page and no breakouts/lightning talks on First Timers
- set quiet-room.show to `true` in conf.yml & check that a) it shows up on A11y, b) it shows up in the subnav menu
- copy example/schedule.yml into the _data dir to test the First Timers page, breakouts/lightning talks should appear using links taken from those schedule events