### PR TITLE
childcare & transportation updates to prospectus

### DIFF
--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -320,13 +320,14 @@ published: true
                     <h3>Childcare</h3>
 
                     <p>
-                        <strong>2 available at $1,500, <span class="text-danger">2 left</span></strong>
+                        <strong>1 available at $2,000, <span class="text-danger">1 left</span></strong>
                     </p>
                     <p>
                         Childcare is provided at the Code4lib Conference to make it possible for working parents and guardians to attend and fully participate. This sponsorship helps to offset the cost of childcare that the attendee using the service will have to pay. Sponsor Benefits include:
                     </p>
                     <ul>
                         <li>Bronze Sponsorship benefits</li>
+                        <li>Signage acknowledging the sponsor</li>
                     </ul>
                 </div>
             </div>
@@ -337,14 +338,14 @@ published: true
                     <h3>Transportation</h3>
 
                     <p>
-                        <strong>2 available at $2,000, <span class="text-danger">2 left</span></strong>
+                        <strong>1 available at $2,000, <span class="text-danger">1 left</span></strong>
                     </p>
                     <p>
                         This Sponsorship opportunity will include sponsoring the cost of  transportation to and from the 2019 Code4Lib opening reception. Sponsor Benefits include:
                     </p>
                     <ul>
                         <li>Bronze Sponsorship benefits</li>
-                        <li>Signage acknowledging the sponsor including a short message from the sponsor</li>
+                        <li>Signage acknowledging the sponsor</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
see `#conference-website` Slack channel for details on this:

kathy.azevedo: "We are getting ready to launch the Sponsorship Registration site. We’ve made a few updates and need the website corrected. Can someone please make the following edits?
(1) Childcare - Change to 1 available at $2,000. Add bullet - “Signage acknowledging the sponsor”.
(2) Transportation - Change to 1 available at $2,000. Remove the following text from second bullet - “including a short message from the sponsor”.
After the site has been published, I will send the link to update the button link. Thanks!"