### PR TITLE
logic for showing transcription sponsor(s)

### DIFF
--- a/_data/examples/sponsors.yml
+++ b/_data/examples/sponsors.yml
@@ -42,6 +42,7 @@
 
 - name: Gabirel's Sporting Goods
   img: /assets/img/examples/sponsors/three.svg
+  link: https://www.google.com
   level: gold
   transcription: true
 

--- a/_data/examples/sponsors.yml
+++ b/_data/examples/sponsors.yml
@@ -4,6 +4,7 @@
   # link: http://www.google.com
   # level: platinum
   # diversity: true
+  # transcription: false
 
 # if img is omitted, the name will be displayed instead.
 
@@ -42,6 +43,7 @@
 - name: Gabirel's Sporting Goods
   img: /assets/img/examples/sponsors/three.svg
   level: gold
+  transcription: true
 
 - name: Oskar's Finery
   img: /assets/img/examples/sponsors/one.svg

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -118,23 +118,37 @@ active: Attend Code4Lib
                 </p>
 
                 <h3>Live Transcription</h3>
+                {% assign sponsors = site.data.sponsors | where:"transcription","true" %}
                 <p>
                     We are thrilled to be able to provide
                     {% if site.data.conf.closed-captioning.show %}
                         <a href="{{site.data.conf.closed-captioning.url}}">
                     {% endif %}
                         live transcriptions of all the presentations
-                    {% if site.data.conf.closed-captioning.show %}</a>{% endif %},
-                    thanks to Temple University Libraries.
+                    {% if site.data.conf.closed-captioning.show %}</a>{% endif %}.
                 </p>
+                {% if sponsors.size > 0 %}
+                    <p>
+                        Thank you to our Transcription sponsor{% if sponsors.size > 1 %}s{% endif %}:
+                    </p>
+                    <ul>
+                        {% for sponsor in sponsors %}
+                            <li>{{ sponsor.name }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
 
-                <div class="row sponsor-row">
-                    <div class="col-xs-12 col-md-6">
-                        <a href="http://library.temple.edu/" class="thumbnail" style="background: white;">
-                            <img src="https://assets.temple.edu/sites/assets/files/images/svg/temple-university-main-logo.svg" alt="Temple University Libraries">
-                        </a>
+                {% for sponsor in sponsors %}
+                    {% if sponsor.img != '' %}
+                    <div class="row sponsor-row">
+                        <div class="col-xs-12 col-md-6">
+                            <a href="{{ sponsor.link }}" class="thumbnail" style="background: white;">
+                                <img src="{{ sponsor.img }}" alt="{{ sponsor.name }}">
+                            </a>
+                        </div>
                     </div>
-                </div>
+                    {% endif %}
+                {% endfor %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
right now it's just the hard-coded value from 2019

testing this you'll want to try out the test data (_data/examples/sponsors.yml). Should not mention a sponsor before you put that file into _data and then look like this with test data: 
<img width="617" alt="Screen Shot 2019-09-25 at 13 55 58" src="https://user-images.githubusercontent.com/1024833/65639238-93dae800-df9c-11e9-88c9-72411bc562d3.png">
