### PR TITLE
fallback focus state for all .btns

### DIFF
--- a/assets/_scss/_global.scss
+++ b/assets/_scss/_global.scss
@@ -36,6 +36,10 @@ h5 {
   }
 }
 
+.btn:focus {
+    @include fixed-tab-focus;
+}
+
 .navbar {
   font-family: $font-family-sans-serif;
   font-weight: 300;

--- a/assets/_scss/_mixins.scss
+++ b/assets/_scss/_mixins.scss
@@ -2,7 +2,7 @@
 
 @mixin fixed-tab-focus() {
   // non-Blink/Webkit browsers get this (Firefox, IE)
-  outline: 5px auto rgba(0, 103, 244, 0.43);
+  outline: 5px auto $tab-focus-color;
   // outline corners will be square without this
   -moz-outline-radius: 5px;
   // Chrome/Safari can use their native focus handling

--- a/assets/_scss/_mixins.scss
+++ b/assets/_scss/_mixins.scss
@@ -1,0 +1,11 @@
+// WebKit-style focus, derived from bootstrap/mixins/_tab-focus.scss
+
+@mixin fixed-tab-focus() {
+  // non-Blink/Webkit browsers get this (Firefox, IE)
+  outline: 5px auto rgba(0, 103, 244, 0.43);
+  // outline corners will be square without this
+  -moz-outline-radius: 5px;
+  // Chrome/Safari can use their native focus handling
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -33,6 +33,10 @@ $brand-danger:            #d9534f !default;
 $accent-link-primary:    #fdb771 !default;
 $accent-primary-hover:   lighten($accent-link-primary, 10%) !default;
 
+// General
+// see fixed-tab-focus in _mixins
+$tab-focus-color: gba(0, 103, 244, 0.43);
+
 //== Code4Lib
 //
 //## Unique Code4Lib conference site components

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -35,7 +35,7 @@ $accent-primary-hover:   lighten($accent-link-primary, 10%) !default;
 
 // General
 // see fixed-tab-focus in _mixins
-$tab-focus-color: gba(0, 103, 244, 0.43);
+$tab-focus-color: rgba(0, 103, 244, 0.43);
 
 //== Code4Lib
 //

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -3,6 +3,7 @@
 
 // these are vars, functions, mixins & need to come first
 @import 'color-contrast';
+@import 'mixins';
 @import 'links';
 @import 'variables';
 @import 'bootstrap/bootstrap';


### PR DESCRIPTION
Closes #31. Firefox didn't show a focus state, this should add one while also retaining the native focus state for Chrome & Safari. Firefox screenshot: 
<img width="396" alt="Screen Shot 2019-10-03 at 13 50 19" src="https://user-images.githubusercontent.com/1024833/66163347-f6f3fc80-e5e4-11e9-8fdb-db6a4417f8cf.png">
Not sure why the first `outline` property is unchecked there...but you can see the effect.

To test:
- pull down changes, build site locally
- open home page in Chrome, either inspect & add `:focus` state to button or keyboard navigate to one
- do the same thing in Firefox
- (ideally) do the same thing in Edge or IE