### PR TITLE
use vars in 'propose a keynote' page not text, closes #44

### DIFF
--- a/general-info/propose-a-keynote.html
+++ b/general-info/propose-a-keynote.html
@@ -19,7 +19,7 @@ categories: keynotes
     <div class="row">
         <div class="col-xs-12">
             <p>
-                Keynote speaker nominations for the 2019 Code4Lib Conference will be accepted until October 22, 2018. Nominations should be made on <a href="{{ site.data.conf.keynote-proposals.submission-form }}">our wiki page</a>.
+                Keynote speaker nominations for the {{ site.data.conf.year }} Code4Lib Conference will be accepted until {{ site.data.conf.keynote-proposals.end-date | date:"%B %-d, %Y" }}. Nominations should be made on <a href="{{ site.data.conf.keynote-proposals.submission-form }}">our wiki page</a>.
             </p>
             <p>
                 The criteria for nominating a candidate to act as keynote are below:
@@ -31,12 +31,7 @@ categories: keynotes
                 <li>Contact information of candidate (email address)</li>
             </ul>
             <p>
-                We encourage you to nominate speakers who are local to the Bay Area. The
-                conference will be held at the DoubleTree by Hilton in {{site.data.conf.location}}, from February 19, 2019 - February 22, 2019.
-            </p>
-            <p>
-                If you would prefer to submit a nomination anonymously, please send your
-                nominee(s) to Clara Turp at <a href="mailto:clara.turp@mcgill.ca">clara.turp@mcgill.ca</a>
+                We encourage you to nominate speakers who are local to the area. The conference will be held at the {{ site.data.conf.venue.name }} in {{ site.data.conf.location }}, from {{ site.data.conf.days[0].date }} to {{ site.data.conf.days[-1].date }}, {{ site.data.conf.year }}.
             </p>
         </div>
     </div>


### PR DESCRIPTION
To test: just render the site and visit /general-info/propose-a-keynote.html (it's linked off the home page)