### PR TITLE
hide sponsor annotations on scholarships page

### DIFF
--- a/_includes/sponsors/logo.html
+++ b/_includes/sponsors/logo.html
@@ -6,7 +6,7 @@
         <span class="sponsor-name-only">{{ sponsor.name }}</span>
         {% endif %}
     </a>
-    {% if sponsor.annotation.size %}
+    {% if !no-annotation and sponsor.annotation.size %}
         <div class="sponsor-annotation">{{ sponsor.annotation}}</div>
     {% endif %}
 </div>

--- a/general-info/scholarships.html
+++ b/general-info/scholarships.html
@@ -125,7 +125,7 @@ subnav:
       {% assign sponsors = site.data.sponsors | where: "diversity", true %}
       <div class="sponsor-group">
         {% for sponsor in sponsors %}
-          {% include sponsors/logo.html sponsor=sponsor %}
+          {% include sponsors/logo.html sponsor=sponsor no-annotation=true %}
         {% endfor %}
       </div>
     </div>


### PR DESCRIPTION
fixes #67

The include/sponsors/logo.html fragment now has some context awareness, you can include it while passing a `no-annotation` boolean to disable those from displaying.