### PR TITLE
sponsors - anchor links for each sponsor level

### DIFF
--- a/_includes/sponsors/group_display.html
+++ b/_includes/sponsors/group_display.html
@@ -1,5 +1,5 @@
 <!-- {{ include.level | capitalize }} -->
-<div class="row">
+<div class="row" id="{{ include.level | slug }}">
     <div class="col-xs-12">
         {% include sponsors/plate.html level=include.level %}
 


### PR DESCRIPTION
this lets us link to e.g. https://2020.code4lib.org/sponsors/#giveaway or https://2020.code4lib.org/sponsors/#platinum