### PR TITLE
close keynote voting, scholarship applications, & angel fund donations

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -275,7 +275,7 @@ volunteer-onsite:
 ################
 
 angel-fund:
-    show: true
+    show: false
     # whether to show the "donation thermometer" & Google Spreadsheet key for it
     thermometer: true
     # NOTE: spreadsheet needs to be "published to the web"
@@ -283,7 +283,7 @@ angel-fund:
     url: https://mxmerchant.com/mxcustomer/d/27881511-a676-4fa5-80cb-9987204864c4/v3
 
 diversity-scholarship-applications:
-  show: true
+  show: false
   url: "/general-info/scholarships#how-to-apply"
   url-text: "How to Apply"
   end-date: "2019-12-02"

--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -163,7 +163,7 @@ host-proposals:
 ###########
 
 keynote-voting:
-  show: true
+  show: false
   url: "https://forms.gle/uDaMVX9nopjjNh5Y8"
   end-date: "2019-12-02"
 

--- a/assets/js/thermometer.js
+++ b/assets/js/thermometer.js
@@ -119,5 +119,5 @@ fetch(total_url)
         let total = data.feed.entry ? new Intl.NumberFormat('en-US',
             {style: 'currency', currency: 'USD'}).format(data.feed.entry[0].content.$t) : "$0"
         // insert into page
-        document.querySelector('#donation-total').innerHTML = `<h2>${total} raised so far.</h2>`
+        document.querySelector('#donation-total').innerHTML = `<h2>${total} raised.</h2>`
     })

--- a/general-info/angel-fund.html
+++ b/general-info/angel-fund.html
@@ -3,12 +3,12 @@
 		<div class="col-xs-12">
 			<h2>Diversity Scholarships Angel Fund</h2>
 			<p>
-				As part of the Code4Lib community's ongoing commitment to helping under-represented groups excel in computing and technology, we offer multiple scholarships to attend the annual conference. In addition to seeking organization sponsors for scholarships, we are accepting donations from individuals who would like to support the scholarship program. Individual donors will be thanked on the Scholarship page, though anonymous donation is also possible. All funds raised will help pay for transportation, accommodation, and conference registration costs for Code4Lib's Diversity Scholarships recipients for our annual conference.
-			</p><p>
+				As part of the Code4Lib community's ongoing commitment to helping under-represented groups excel in computing and technology, we offer multiple scholarships to attend the annual conference. In addition to seeking organization sponsors for scholarships, we accept donations from individuals who would like to support the scholarship program. Individual donors will be thanked on the Scholarship page, though anonymous donation is also possible. All funds raised will help pay for transportation, accommodation, and conference registration costs for Code4Lib's Diversity Scholarships recipients for our annual conference.
+			</p>
+            {% if site.data.conf.angel-fund.show %}
+            <p>
 				When donating, select a matching fund using the <strong>Special Designation</strong> drop-down menu. Please feel free to direct any question to <a href="mailto:{{ site.data.conf.sponsor-contact-email }}">{{ site.data.conf.sponsor-contact-email }}</a>.
 			</p>
-
-			{% if site.data.conf.angel-fund.show %}
 			<div>
 				<a class="btn btn-primary btn-lg" href="{{ site.data.conf.angel-fund.url }}" target="_blank">Donate to the Angel Fund today!</a>
 			</div><br>

--- a/general-info/scholarships.html
+++ b/general-info/scholarships.html
@@ -199,6 +199,4 @@ subnav:
 </div>
 </section>
 
-{% if site.data.conf.angel-fund.show %}
-    {% include_relative angel-fund.html %}
-{% endif %}
+{% include_relative angel-fund.html %}


### PR DESCRIPTION
to test:

- home page shouldn't mention scholarships or keynote
- gen-info / scholarships shouldn't talk about accepting application & should display Angel Fund information but without soliciting donations