### PR TITLE
sponsors finalized for now, closes #92

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -108,8 +108,8 @@ closed-captioning:
 ###########
 
 # If true, any "Sponsors" links will go to /prospectus instead of /sponsors
-call-for-sponsors: true
-homepage-sponsor-button: true
+call-for-sponsors: false
+homepage-sponsor-button: false
 # URL to document
 prospectus-document: '/assets/2020_c4l_Infosheet.pdf'
 sponsor-btn-link: 'https://www.eiseverywhere.com/sponsor.c4l20'


### PR DESCRIPTION
- hide 'sponsor us' button on home page
- Sponsors menu link -> sponsors not prospectus

we are still missing details & logos for some sponsors but
we are OK to make this change for now, those will trickle
in over time I imagine