### PR TITLE
show more program/speaker info even without schedule

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -8,9 +8,17 @@ location: 'Pittsburgh, Pennsylvania'
 hero-image-alt: "Daytime photo of Pittsburgh downtown area with gray clouds framed by yellow bridges"
 
 search: false
-# If false (we don't have program info yet), the main nav links go:
-# schedule -> preparation timeline, speakers -> past keynotes
-program-nav-links: false
+
+########################
+# Program & Schedule
+#######################
+# These booleans affect the main menu links in the ways described below, as well
+# as displays in a few other places.
+# if true Speakers link -> /speakers/, if false -> /speakers/past-keynotes
+have-talks: true
+have-workshops: false
+# if true Schedule link -> /schedule/, if false -> /schedule/timeline
+have-schedule: false
 
 # day 0 = preconf day
 days:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,13 +4,12 @@
         <ul class="list-inline list-unstyled small">
             <li class="list-item tci"><a href="{{ site.baseurl }}/">Home</a></li>
 
-            {% if site.data.conf.program-nav-links %}
-                <li class="list-item tci"><a href="{{ site.baseurl }}{% link schedule/index.html %}">Schedule</a></li>
-                <li class="list-item tci"><a href="{{ site.baseurl }}{% link speakers/index.html %}">Speakers</a></li>
-            {% else %}
-                <li class="list-item tci"><a href="{{ site.baseurl }}{% link schedule/timeline.html %}">Schedule</a></li>
-                <li class="list-item tci"><a href="{{ site.baseurl }}{% link speakers/past-keynotes.html %}">Speakers</a></li>
-            {% endif %}
+            <li class="list-item tci"><a href="{{ site.baseurl }}{% if site.data.conf.have-schedule %}
+            {% link schedule/index.html %}{% else %}{% link schedule/timeline.html %}
+            {% endif %}">Schedule</a></li>
+            <li class="list-item tci"><a href="{{ site.baseurl }}{% if site.data.conf.have-talks %}
+            {% link speakers/index.html %}{% else %}{% link speakers/past-keynotes.html %}
+            {% endif %}">Speakers</a></li>
 
             {% if site.data.conf.call-for-sponsors %}
                 <li><a href="{{ site.baseurl }}{% link prospectus/index.html %}">Sponsors</a></li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,17 +15,14 @@
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">
 
-                <!-- HOME -->
                 <li><a href="{{ site.baseurl }}/" aria-label="Return to Code4Lib Index Page">Home</a></li>
 
-                {% if site.data.conf.program-nav-links %}
-                    <li><a href="{{ site.baseurl }}{% link schedule/index.html %}">Schedule</a></li>
-                    <li><a href="{{ site.baseurl }}{% link speakers/index.html %}">Speakers</a></li>
-                {% else %}
-                    <!-- Information for before we have program/preconf details -->
-                    <li><a href="{{ site.baseurl }}{% link schedule/timeline.html %}">Schedule</a></li>
-                    <li><a href="{{ site.baseurl }}{% link speakers/past-keynotes.html %}">Speakers</a></li>
-                {% endif %}
+                <li><a href="{{ site.baseurl }}{% if site.data.conf.have-schedule %}
+                {% link schedule/index.html %}{% else %}{% link schedule/timeline.html %}
+                {% endif %}">Schedule</a></li>
+                <li><a href="{{ site.baseurl }}{% if site.data.conf.have-talks %}
+                {% link speakers/index.html %}{% else %}{% link speakers/past-keynotes.html %}
+                {% endif %}">Speakers</a></li>
 
                 {% comment %}
                 when looking for sponsors before conf, send users to prospectus

--- a/_includes/talks-and-workshops-buttons.html
+++ b/_includes/talks-and-workshops-buttons.html
@@ -1,0 +1,26 @@
+{% comment %}
+this include can be used in places where we'd normally show a full schedule when
+we have talk/workshop information but don't yet know the exact schedule
+{% endcomment %}
+{% if site.data.conf.have-talks or site.data.conf.have-workshops %}
+    <div class="row">
+        <div class="col-xs-12">
+            {% if site.data.conf.have-workshops %}
+                <div class="col-md-4">
+                    <a href="{{ site.baseurl }}{% link workshops/index.html %}" class="btn btn-primary btn-lg">
+                        View Preconference Workshops
+                    </a>
+                </div>
+            {% endif %}
+
+            {% if site.data.conf.have-talks %}
+                <div class="col-md-4">
+                    <a href="{{ site.baseurl }}{% link talks/index.html %}" class="btn btn-primary btn-lg">
+                        View Conference Talks
+                    </a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+    <br>
+{% endif %}

--- a/_layouts/day-schedule.html
+++ b/_layouts/day-schedule.html
@@ -5,12 +5,15 @@
     <div class="row">
         <div class="col-xs-12">
             <h1>{{ page.title }}</h1>
-            {% if site.data.conf.program-nav-links %}
+            {% if site.data.conf.have-schedule %}
                 {% include schedule_nav.html param=page.day %}
                 {{ content }}
                 {% assign events = site.data.schedule | where:page.day, true %}
                 {% include presentation_timeline.html events=events %}
                 {% include schedule_nav.html param=page.day %}
+            {% else %}
+                <p>The schedule for Code4Lib {{site.data.conf.year}} has not been finalized yet.</p>
+                {% include talks-and-workshops-buttons.html %}
             {% endif %}
         </div>
     </div>

--- a/schedule/timeline.html
+++ b/schedule/timeline.html
@@ -12,6 +12,9 @@ categories: Schedule
                 <p>Over the coming months, we'll be gathering proposals and voting on conference speakers and activities.</p>
             </div>
         </div>
+
+        {% include talks-and-workshops-buttons.html %}
+
         <div class="row">
             {% include homepage/pre_conference.html %}
         </div>


### PR DESCRIPTION
This is a decent-sized PR that introduces some new toggles in conf.yml which let us show more information on talks, workshops, & speakers without needing to know the exact schedule.

# Testing

conf.yml has three new toggles up at the top now: `have-talks`, `have-workshops`, `have-schedule`. These replace the old `program-nav-links` toggle. Currently `have-talks` is true while the other two are false. After applying the PR, I'd test these things and use `bundle exec jekyll serve --drafts` so you have a draft workshop post:

- test as is
  + Schedule main menu/footer links -> schedule/timeline, Speakers link -> /speakers/
  + button for talks displays on /schedule/timeline and on /schedule/day-1/
- activate `have-workshops`
  + now there are two buttons on /schedule/timeline and /schedule/day-1/
- copy _data/examples/schedule.yml into _data/\* & activate `have-schedule`
  + Schedule main menu/footer links -> /schedule/
- deactivate all three
  + back to our current state, no buttons on /schedule/timeline nor /schedule/day-1/
  + Speakers main menu/footer links -> /speakers/past-keynotes, Schedule -> /schedule/timeline

\* Without schedule.yml Jekyll will throw a "cannot sort a null object" error as it tries to sort an empty list  so we need this fake data to even make the site build when this toggle is on.