### PR TITLE
update 2 URLs, see Slack

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -115,7 +115,7 @@ call-for-sponsors: false
 homepage-sponsor-button: false
 # URL to document
 prospectus-document: '/assets/2020_c4l_Infosheet.pdf'
-sponsor-btn-link: 'https://www.eiseverywhere.com/sponsor.c4l20'
+sponsor-btn-link: 'https://na.eventscloud.com/sponsor.c4l20'
 
 ##########
 # !!!NOTE!!! All 'end-date' vars should be in the following format: YYYY-MM-DD

--- a/_data/registration.yml
+++ b/_data/registration.yml
@@ -7,14 +7,14 @@
 workshop-only:
   # "show" only affects a button on the general-info/attend page
   show: false
-  url: "https://www.eiseverywhere.com/c4l20"
+  url: "https://na.eventscloud.com/c4l20"
   half-day-cost: "$50"
   full-day-cost: "$100"
 
 # "show" just means display on home page, "open" means people can register
 conference:
   show: true
-  url: "https://www.eiseverywhere.com/c4l20"
+  url: "https://na.eventscloud.com/c4l20"
   start-date: 2019-12-11
   end-date: 2020-02-08
   cancellation-date: 2020-02-12


### PR DESCRIPTION
Kathy told us that the registration/sponsorship URLs have changed because the company they worked with changed domain names. I think these are the only two places we put them but please double-check.