### PR TITLE
fix keynotes pages

### DIFF
--- a/_posts/2019-02-22-Alison-Langmead.html
+++ b/_posts/2019-02-22-Alison-Langmead.html
@@ -1,7 +1,7 @@
 ---
 layout: presentation
 speakers-text: Alison Langmead
-speaker: alison-langmead
+speakers: alison-langmead
 day: 3
 group: key-close
 spot: 1

--- a/_posts/2020-03-09-Alison-Macrina.html
+++ b/_posts/2020-03-09-Alison-Macrina.html
@@ -1,7 +1,7 @@
 ---
 layout: presentation
 speakers-text: Alison Macrina
-speaker: alison-macrina
+speakers: alison-macrina
 day: 1
 group: key-open
 spot: 1


### PR DESCRIPTION
fix keynotes pages to display talk info and speaker name/image, e.g.:

https://2020.code4lib.org/keynotes/Alison-Macrina