### PR TITLE
note childcare registration end date

### DIFF
--- a/_data/registration.yml
+++ b/_data/registration.yml
@@ -23,3 +23,4 @@ conference:
   late-cost: "$450"
 
 reception-plus-one-cost: "$60"
+childcare-end-date: 2020-02-08

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -70,17 +70,11 @@ active: Attend Code4Lib
                 <ol>
                     <li>
                         Child Care is available for each day of the conference. When you register, you may select which days you require child care. The cost is $30 per full day, $15 for the half day on {{ site.data.conf.days[3].weekday }}, and $15 for child care during the {{ site.data.conf.days[1].weekday }} evening reception.
+                        {% if site.data.registration.childcare-end-date != '' %}
+                          <strong>Please Note</strong>: Child Care Registration will close on {{ site.data.registration.childcare-end-date | date: "%B %e, %Y" }}. Registration and payment must be finalized on or before {{ site.data.registration.childcare-end-date | date: "%B %e"}}, to utilize the child care services.
+                        {% endif %}
                     </li>
-                    {% comment %}
-                    <li>
-                        The registration system maintains a two hour session per registration
-                        attempt. Due to the potential of heavy access and this prolonged session,
-                        the conference may appear to sell out quickly. But once early failed
-                        sessions expire, more spots may open up beginning around 2 p.m. Because of
-                        this we ask you not to assume it is sold out until you hear an announcement
-                        from the planning committee.
-                    </li>
-                    {% endcomment %}
+
                     <li>
                         Registration will close when the maximum capacity has been reached.
                         A waitlist will be available once this final round of registration is

--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -320,7 +320,7 @@ published: true
                     <h3>Childcare</h3>
 
                     <p>
-                        <strong>1 available at $2,000, <span class="text-danger">1 left</span></strong>
+                        <strong><span class="text-danger">None available</span> at $2,000</strong>
                     </p>
                     <p>
                         Childcare is provided at the Code4lib Conference to make it possible for working parents and guardians to attend and fully participate. This sponsorship helps to offset the cost of childcare that the attendee using the service will have to pay. Sponsor Benefits include:

--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -341,7 +341,7 @@ published: true
                         <strong><span class="text-danger">None available</span> at $2,000</strong>
                     </p>
                     <p>
-                        This Sponsorship opportunity will include sponsoring the cost of transportation to and from the 2019 Code4Lib opening reception. Sponsor Benefits include:
+                        This Sponsorship opportunity will include sponsoring the cost of transportation to and from the {{ site.data.conf.year }} Code4Lib opening reception. Sponsor Benefits include:
                     </p>
                     <ul>
                         <li>Bronze Sponsorship benefits</li>


### PR DESCRIPTION
also fix one hard-coded year on the Prospectus. These changes are coming from a discussion in Slack.