### PR TITLE
FIX: remove unnecessary end tag

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -54,7 +54,7 @@
 {% if page.title == 'Venues' %}
 <script src="https://kit.fontawesome.com/bd2d035961.js" crossorigin="anonymous"></script>
 <script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<link rel="stylesheet" href="http://cdn.datatables.net/1.10.13/css/jquery.dataTables.min.css"></script>
+<link rel="stylesheet" href="http://cdn.datatables.net/1.10.13/css/jquery.dataTables.min.css">
 <script src="http://cdn.datatables.net/1.10.13/js/jquery.dataTables.min.js"></script>
 <script>
   $(document).ready(function() {


### PR DESCRIPTION
Table sort functionality works on localhost, but did not function on the GitHub hosted site. I've removed an unnecessary closing tag that I missed in my editor last night, but I'd appreciate a quick review.