### PR TITLE
add scholarship recipients, closes #90

### DIFF
--- a/_data/scholarship-recipients.yml
+++ b/_data/scholarship-recipients.yml
@@ -1,0 +1,39 @@
+- name: Andy Hickner
+  bio: I am a Health Sciences Librarians at Seton Hall University in New Jersey, where I am one of the liaisons for the Hackensack Meridian School of Medicine. I helped co-found the IHS Library when it opened on Seton Hall's new health sciences campus in 2018. I have over a decade of experience building and managing websites and conducting user experience research.
+  twitter_handle: andyhickner
+
+- name: Esther Jackson
+  bio:
+  twitter_handle:
+
+- name: Heather Greer Klein
+  bio: Heather Greer Klein is an Outreach & Engagement Coordinator for Digital Technology Services at LYRASIS (previously DuraSpace), where she helps connect libraries and cultural heritage institutions to open source services that will best meet their needs. She is passionate about making open technology solutions understandable and accessible to institutions of all types and sizes.
+  twitter_handle:
+
+- name: Eileen López
+  bio: Eileen is a second year MSLIS student at the University of Illinois. Her research interests include design-based research for healthcare and higher education, civic technology, and evaluation methods. She has worked previously as a visual designer at several non-profit organizations and startups and plans to shift into working in user research and assessment after graduating this May. This will be her first Code4Lib conference.
+  twitter_handle: eileenmatilde
+
+- name: Adetomiwa Basiru
+  bio: Dr.  Adetomiwa  Basiru is a Senior Librarian with Redeemer’s University, Ede, Osun state, Nigeria. He is a young librarian with firm interest in emerging technologies especially those that enhance efficiency and effectiveness of people in both work and personal life. His innovativeness and professional proficiency have helped to modernize the Redeemer’s University Library services.
+  twitter_handle: tommybashy06
+
+- name: Samuel Bello
+  bio: Mr. Samuel Bello is a certified Librarian, currently heading the Africa Regional Centre for Information Science Library unit, under the University Library, University of Ibadan, Nigeria. He provides e-resources (using online databases) for teaching and research and engage in digital health information & communication. He holds NCE Certificate from Lagos State College of Education, Diploma from University of Ibadan, BLIS degree from University of Ibadan, MLIS also from University of Ibadan and MIT from University of Pretoria, South Africa. He is the first Nigerian male Carnegie Master's degree academic grant scholar. He is a member of some professional associations both locally and internationally.
+  twitter_handle:
+
+- name: Brighid M. Gonzales
+  bio: Brighid is the Systems and Web Services Librarian at Our Lady of the Lake University in San Antonio, TX where she manages the library website along with the library's technology systems. She is also an editorial member of the Code4Lib Journal.
+  twitter_handle: BrighidMG
+
+- name: Sharon Luong
+  bio: Sharon works at UNC Chapel Hill Libraries as a software developer on a grant-funded audiovisual archiving app. She is new to coding for libraries and previously worked at a local tech company. Sharon looks forward to learning more about library web development, diversity & inclusion, and new technologies.
+  twitter_handle:
+
+- name: Jennifer Patiño
+  bio: Jennifer Patiño is the Data and Digital Scholarship Resident Librarian at the University of Wisconsin-Madison. She is an early career academic librarian with a background in community archives and arts publishing at Sixty Inches From Center. She is a proud ALA Spectrum Scholar and received her MSLIS at the University of Illinois at Urbana-Champaign. She has a BA in Art History from Columbia College Chicago with minors in Latinx Studies and Poetry.
+  twitter_handle:
+
+- name: Ashley Evans Bandy
+  bio: Ashley Evans Bandy recently graduated from UCLA with her MLIS and joined NC State University as a Libraries Fellow in both the departments of Acquisitions & Discovery and Data & Visualization Services. Her current research interests include ethics in digital access to information, algorithmic decision making, and critical aspects of data and visualization.
+  twitter_handle:

--- a/assets/_scss/_global.scss
+++ b/assets/_scss/_global.scss
@@ -45,6 +45,10 @@ h5 {
   font-weight: 300;
 }
 
+dt {
+    margin-top: 1em;
+}
+
 p {
   line-height: 2em;
 }

--- a/general-info/scholarships.html
+++ b/general-info/scholarships.html
@@ -4,6 +4,8 @@ title: General Info
 nav: general-info
 active: Scholarships
 subnav:
+- name: Recipients
+  url: '#recipients'
 - name: 'Eligibility, Criteria, & Requirements'
   url: '#criteria'
 - name: 'How to Apply'
@@ -49,7 +51,7 @@ subnav:
                 {% endif %}
 
                 {% if site.data.scholarship-recipients %}
-                    <h2>{{year}} Code4Lib Scholarship Recipients</h2>
+                    <h2 id="recipients">{{year}} Code4Lib Scholarship Recipients</h2>
                     <p>
                         The Scholarship Committee is pleased to announce the
                         Code4Lib {{year}} Conference Diversity Scholarship awardees.
@@ -84,10 +86,14 @@ subnav:
                             </dt>
                             {% if person.bio.size > 0 %}
                                 <dd>{{ person.bio }}</dd>
+                            {% else %}
+                                <dd class="sr-only">No bio provided.</dd>
                             {% endif %}
-                            <br>
                         {% endfor %}
                     </dl>
+                {% else %}
+                {% comment %} remove from secondary nav (jQuery not yet on page) {% endcomment %}
+                <script>document.querySelector('.secondarynav a[href="#recipients"]').parentElement.remove()</script>
                 {% endif %}
         </div>
     </div>
@@ -114,7 +120,6 @@ subnav:
    </div>
 </div>
 {% endif %}
-</section>
 
 {% if site.data.conf.diversity-scholarship-sponsors.show  %}
 <div class="container-fluid">
@@ -133,7 +138,6 @@ subnav:
 </div>
 {% endif %}
 
-<section class="general-info">
 <div class="container-fluid">
    <div class="row">
        <div class="col-xs-12">
@@ -197,6 +201,6 @@ subnav:
        </div>
    </div>
 </div>
-</section>
 
 {% include_relative angel-fund.html %}
+</section>


### PR DESCRIPTION
Also: add Recipients secondary nav link, hide it if recipients aren't shown, proper `<dl>` structure to pass accessibility audit. To test:

- apply this PR, build the site, & visit http://127.0.0.1:4000/general-info/scholarships
- Recipients should be secondary nav item & list of people will be on the page
- page passes Chrome accessibility audit (`<dl>` can only have `<dd>` & `<dt>` children, there must be at least one `<dd>` for every `<dt>` whether or not we have a bio)
- rename or delete the _data/scholarship-recipients.yml file—now the Recipients menu item should disappear and the list of people also