### PR TITLE
rm broken instagram link per #151

### DIFF
--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -123,8 +123,8 @@ active: Attend Code4Lib
                     You can also connect with us via
                     <a href="{{ site.data.conf.social-links.slack}}">Slack</a>
                     (requires <a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">registration</a>),
-                    <a href="https://twitter.com/hashtag/{{site.data.conf.hashtag}}">Twitter</a>,
-                    <a href="{{ site.data.conf.social-links.irc}}">IRC</a>, and <a href="https://instagram.com/explore/tags/{{site.data.conf.hashtag}}/">Instagram</a>.
+                    <a href="https://twitter.com/hashtag/{{site.data.conf.hashtag}}">Twitter</a>, and
+                    <a href="{{ site.data.conf.social-links.irc}}">IRC</a>.
                 </p>
 
                 <h3>Live Transcription</h3>


### PR DESCRIPTION
I think we should just remove this link rather than change to a different
hash tag or wait until someone has used the current year's hashtag before
linking to it. I'm open to disagreement, doesn't seem a huge deal either
way.