### PR TITLE
add posters

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -101,7 +101,7 @@
   title: Poster Session
   day2: true
   time: 15:20 - 15:50
-  # link: https://wiki.code4lib.org/Code4Lib2020_Posters#Code4Lib2020_Posters
+  link: /posters/
 
 # wrap ups
 - timeImg: 5.10.png

--- a/_posts/2020-03-10-3D-Print-Your-Data.md
+++ b/_posts/2020-03-10-3D-Print-Your-Data.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Thomas San Filippo
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: 3D Print Your Data
+---
+Got multidimensional data? Print it out! Learn how to 3D print numerical data with the open-source tools, Tangible, OpenSCAD and Slic3r. This poster presents a case study and model demonstrating the necessary steps to transform your data from CSV to cylinder, spreadsheet to spheroid, text to torus (or to any number of other fun representative shapes). Our model “clock” translates output from a continuous glucose monitor into a display of blood glucose fluctuations throughout a typical day. With a simple Python script, we import the Tangible library to convert those data into OpenSCAD code. OpenSCAD then renders the shape, allowing us to export an STL file that we can take to the friendly students in our makerspace lab for extrusion on one of our Prusa i3 MK3 3D printers. There, we put the final touches on our model -- scaling and smoothing it with Slic3r and choosing our color -- and print.

--- a/_posts/2020-03-10-A-tentative-project-of-Engatibased-Chatbot-for-reference-desk-.md
+++ b/_posts/2020-03-10-A-tentative-project-of-Engatibased-Chatbot-for-reference-desk-.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Shu Wan
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: A tentative project of Engati-based Chatbot for reference desk. 
+---
+Along with the development of Artificial Intelligence, AI, technology, chatbots have been increasingly used in the library space. Along with the increasing research literature regarding the potential of AI technology in improving customer services, chatbot has been widely used in answering simple questions and greeting to patrons in practice in recent years. However, the potential of this technology in reference service has rarely been discussed. In this poster, we plan to display the outcome of our research on building a tentative reference services chatbot on the basis of the chatbot platform Engati. The outcome of our research still shows the potential of AI technology in assisting reference librarian with their everyday work.

--- a/_posts/2020-03-10-Advancing-Hyku-improving-institutional-repositories-for-Green-Open-Access.md
+++ b/_posts/2020-03-10-Advancing-Hyku-improving-institutional-repositories-for-Green-Open-Access.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Brian Hole (Ubiquity Press), Ellen Ramsey (University of Virginia)
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Advancing Hyku&#58; improving institutional repositories for Green Open Access
+---
+Advancing Hyku is collaborative project to support the growth of open access through institutional repositories, by introducing significant structural improvements and new features to the Samvera Community's open source Hyku platform. The project partners are University of Virginia Library, Ubiquity Press and the British Library, with funding from Arcadia, a charitable fund of philanthropists Lisbet Rausing and Peter Baldwin. The project runs October 2019-August 2021. This poster will detail the features being developed for auto-population, visualization, annotation, author profiling, metrics and long-term preservation. It will also solicit community feedback on working prototypes.

--- a/_posts/2020-03-10-Applying-Photogrammetry-to-Library-Collections.md
+++ b/_posts/2020-03-10-Applying-Photogrammetry-to-Library-Collections.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Ann Marie Mesco, Emma Slayton, Jon Mcintire, and Joe Mesco, Carnegie Mellon University Libraries 
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Applying Photogrammetry to Library Collections
+---
+Through a collaborative effort with Digital Humanists, Carnegie Mellon University Libraries' Digitization Lab is expanding its services to integrate photogrammetry—a cost-effective method to render physical objects or structures into digital 3-D models. An emerging technology in libraries, photogrammetry offers an augmented approach to document and preserve three-dimensional objects and historical artifacts. This poster will demonstrate the steps that CMU Libraries’ Digitization Lab has taken to integrate 3-D rendering into its workflow and how we are preparing to offer this new digital service—including workshops in conjunction with Digital Humanities—to the greater campus community. 

--- a/_posts/2020-03-10-CCPLUS-Consortia-Collaborating-on-a-Platform-for-Library-Usage-Statistics.md
+++ b/_posts/2020-03-10-CCPLUS-Consortia-Collaborating-on-a-Platform-for-Library-Usage-Statistics.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Gretchen Gueguen, PALCI
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: CC-PLUS&#58; Consortia Collaborating on a Platform for Library Usage Statistics
+---
+CC-PLUS is an open source software platform that provides libraries and consortia with a usage statistics tool to support data-driven stewardship decisions. Using the SUSHI protocol, CC-PLUS harvests COUNTER-compliant reports from multiple vendors into a single shared database. Reports are harvested automatically on a schedule determined by each institution, then they're verified and combined to allow for customized report outputs. Multiple consortia have come together to design special features to support consortial workflows and sharing within the platform. These allow for both single library and shared consortial administration of the final product. CC-PLUS is created using the open-source Laravel framework and will be available with an Apache software license. This project was funded in-part by IMLS.

--- a/_posts/2020-03-10-Crowdsourcing-for-Metadata-Enrichment-and-Outreach-Harnessing-the-Institutional-Memory-of-the-Crowd.md
+++ b/_posts/2020-03-10-Crowdsourcing-for-Metadata-Enrichment-and-Outreach-Harnessing-the-Institutional-Memory-of-the-Crowd.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Colleen Farry, Digital Services Librarian, University of Scranton
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Crowdsourcing for Metadata Enrichment and Outreach&#58; Harnessing the Institutional Memory of the Crowd
+---
+This poster will present a digital initiative at the University of Scranton for a crowdsourcing platform to generate descriptive metadata for a digital collection of archival campus photographs. The goals of this initiative are to enhance the discoverability of resources through metadata enrichment and to provide an outreach opportunity to engage alumni. The crowdsourcing platform creates a space for alumni, as well as the broader campus community, to browse and interact with photographs that span four decades at the university. This project asks a community of users to share their knowledge of the people, places and events documented in the photographs to serve as access points to the digital collection. With the promise of crowdsourcing comes some larger questions for digital archivists and librarians. This poster will discuss some of the open questions for the project team: 1.) What encourages contributors to participate on crowdsourced projects? 2.) What are the potential complications with crowdsourcing? 3.) How is quality measured and success defined? and 4.) How effective is crowdsourcing as an outreach strategy? 

--- a/_posts/2020-03-10-Customizing-WebPac-Pro-with-Bootstrap-to-improve-user-experience.md
+++ b/_posts/2020-03-10-Customizing-WebPac-Pro-with-Bootstrap-to-improve-user-experience.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Nicholas Dease, Digital Learning Librarian, Pratt Institute Libraries
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Customizing WebPac Pro with Bootstrap to improve user experience
+---
+The most current build of Innovative’s WebPAC Pro OPAC lacks responsive features, which makes it very difficult to navigate on mobile and tablet. By integrating the open source Bootstrap front-end framework, WebPac pro can be customized to be fully responsive and mobile friendly. This poster highlights how WebPac Pro can be customized, the steps developers should take to identify areas for improvement, and a brief overview of the process of integrating bootstrap into the existing structure.

--- a/_posts/2020-03-10-DokuWiki-as-a-Knowledge-Base.md
+++ b/_posts/2020-03-10-DokuWiki-as-a-Knowledge-Base.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Angelo Sideris
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: DokuWiki as a Knowledge Base
+---
+This poster walks through using DokuWiki with the Active Directory plugin to give different groups of library staff access to technical support (FAQs) for computers, printers, and software. It also serves as a knowledge base for IT staff to manage and coordinate processes involving the ILS, SQL Server, Task Manager, and custom python scripts.

--- a/_posts/2020-03-10-Drupal-7-to-Drupal-8-What-a-Long-Strange-Trip-Its-Been.md
+++ b/_posts/2020-03-10-Drupal-7-to-Drupal-8-What-a-Long-Strange-Trip-Its-Been.md
@@ -1,0 +1,13 @@
+---
+speakers-text: Meredith Wynn, North Carolina State University Libraries
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Drupal 7 to Drupal 8&#58; What a Long, Strange Trip It's Been
+---
+Hundreds of academic libraries use Drupal to organize and display content on the web - but less than 40% of sites using Drupal have upgraded to D8 (according to [Drupal.org](https://drupal.org) usage statistics), and support for D7 is ending in less than 2 years. This poster will walk you through the process of upgrading your Drupal 6 or 7 site to Drupal 8, drawing on lessons learned from upgrading NC State University Libraries’s Drupal site in 2018 and our experiences since the upgrade.
+
+Getting from Drupal 7 to Drupal 8 is more of a migration than an upgrade, but we’ve found D8 to be well worth the effort. This poster will review criteria for deciding whether (and when) to migrate, benefits of Drupal 8 over Drupal 7, and how we prepared our stakeholders for the migration. Other topics covered will include Drupal’s “Migrate” and “Migrate Plus” modules, how to efficiently migrate pieces of your site that can’t utilize these modules, testing strategies for your new Drupal 8 site and how to communicate with content editors post-migration.

--- a/_posts/2020-03-10-Establishing-Governance-for-Project-and-Service-Management.md
+++ b/_posts/2020-03-10-Establishing-Governance-for-Project-and-Service-Management.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Jason Glenn, Carnegie Mellon University and Kenneth Rose, Carnegie Mellon University
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Establishing Governance for Project and Service Management
+---
+Recently, the Carnegie Mellon University Libraries began to implement a new strategic plan, which greatly increased the number, complexity, and scope of new projects and services sponsored by the Libraries. Historically, initiation, planning, and management of projects and services within Libraries lacked both codified processes and uniform management tools. Libraries’ leadership quickly realized that the rapid increase in the size of the unit's project and service footprints had rendered such an unstructured approach to project and service management untenable. In response to leadership's concerns, the Libraries’ Digital Strategy team launched an effort to establish a structure of governance around project and service management within the University Libraries. This paper will review the selection process for new project and service portfolio management tools, as well as the effort to define project initiation and management and service transition guidelines, with the intent of providing a framework for establishing project and service management governance in similar organizations.

--- a/_posts/2020-03-10-Extracting-with-Style-Using-Natural-Language-Processing-to-Generate-Summaries-of-Rare-Materials.md
+++ b/_posts/2020-03-10-Extracting-with-Style-Using-Natural-Language-Processing-to-Generate-Summaries-of-Rare-Materials.md
@@ -1,0 +1,13 @@
+---
+speakers-text: Jeremiah Flannery
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Extracting with Style&#58; Using Natural Language Processing to Generate Summaries of Rare Materials
+---
+In our collection, the majority of resources have a blank summary field (MARC 520), presenting an opportunity for us to improve resource discovery for patrons. Not only can a good resource summary help a patron decide if they want to access a resource without leaving the library website, but the summary field is an indexed field that can increase a resource’s discoverability in our search layer. (In house analysis of our bibliographic and usage data has shown that there is a correlation, not necessarily causation, between patron usage of a resource and its length of summary field.)
+
+Using special collections documents here at Notre Dame, I extracted keywords based on co-appearances of words and generated summaries with Natural Language Processing methods for extractive summarization. I present samples of results from the project, quantitative analysis (via ROUGE metric, a common performance measure in NLP), and discuss further use for improving library records.

--- a/_posts/2020-03-10-Indexing-Shared-File-Stores-to-Mine-Folksonomy-and-Clear-ROT.md
+++ b/_posts/2020-03-10-Indexing-Shared-File-Stores-to-Mine-Folksonomy-and-Clear-ROT.md
@@ -1,0 +1,12 @@
+---
+speakers-text: Camille Mathieu, Rebecca Townsend, and Sara Bond; Jet Propulsion Laboratory
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Indexing Shared File Stores to Mine Folksonomy and Clear ROT
+---
+Shared folder structures, like those contained in network drives and cloud-based files stores, represent a rich -- and underutilized -- source of descriptive information. Since network drives and web collaboration tools are usually where shared folder structures are found, these structures can be considered effective folksonomies, as folder titles and organization in these spaces was likely "crowdsourced" from the team that uses them. Similarly, as shared file stores are frequently used as work areas for teams, these stores are very likely to house ROT (Redundant, Obsolete, Trivial) information. Both the underutilization of folder structures in shared file stores and the accumulation of information ROT are symptoms of file stores being used by teams for decades, but largely ignored by digital transformation and other organizational information strategy efforts.
+Now, our team at the Jet Propulsion Laboratory is seeking to alleviate these issues by 1) parsing folder structure information, and 2) indexing the parsed file information so that it can be assessed from a single view to determine whether it should be retained or dispositioned. This poster will address the technical challenges of parsing folders and files using Apache Tika, and discuss assessment strategies enabled by the index. Overall, this poster seeks call information professionals' attention to these digital "junk drawers," so we may understand what value they can offer individuals and organizations after decades of accumulation and description without evaluation.

--- a/_posts/2020-03-10-Insourcing-authority-control.md
+++ b/_posts/2020-03-10-Insourcing-authority-control.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Mike Monaco, Coordinator, Cataloging Services, The University of Akron
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Insourcing authority control
+---
+Access and discovery of library resources in the catalog depends on consistent, authorized access points. Some libraries turn to outside vendors to provide automated authority control, but this can be too expensive for many. This poster explains some simple tricks that even the coding-challenged can use to begin in-sourcing automated authority control using SQL queries and regular expressions to process reports from Innovative Sierra and SirsiDynix Symphony and retrieve matching authority records with OCLC Connexion Client.

--- a/_posts/2020-03-10-Lets-Talk-About-Contingent-Labor.md
+++ b/_posts/2020-03-10-Lets-Talk-About-Contingent-Labor.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Amy Wickner, Ruth Tillman
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Let’s Talk About Contingent Labor
+---
+Are you on your third 3-year project to build the next big thing in libraries? Did you get hired to start a digital archiving program in 2 years with contract renewal up in the air? Contingent labor in libraries looks like a lot of things, from contracting developers to grant projects to strategic term positions to grad student work to interns. In 2019, the [Collective Responsibility Forum](https://laborforum.diglib.org) brought together one group of workers to talk about their experiences of contingency and its impacts. We wrote recommendations for building better grants. Now, we’re building networks and tools to continue the conversation with other workers across the LAM spectrum. We’ll bring materials to share but, more importantly, we want to talk with you!

--- a/_posts/2020-03-10-Macro-Migration-Implementing-a-CloudBased-Metadata-Microservice-with-Fedora.md
+++ b/_posts/2020-03-10-Macro-Migration-Implementing-a-CloudBased-Metadata-Microservice-with-Fedora.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Tommy Ferguson, Julie Holdener, Mark Murabayashi, Anna Oates
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Macro Migration&#58; Implementing a Cloud-Based Metadata Microservice with Fedora
+---
+This poster illustrates a Fedora-based metadata microservice that utilizes Amazon Web Services (AWS) and other cloud-based products for indexing, storing Resource Description Framework triples and files, and managing Docker containers, demonstrated in a beta implementation of a publication metadata discovery layer. When embarking upon the 10-month project to develop a new administrative and discovery platform for the publication metadata, we prioritized the use of open source software, linked open data, widely adopted metadata standards, and interoperability with local systems. After exploring existing Fedora-based frameworks, we found that forcing those, such as Samvera or Islandora, imposed challenges that could be mitigated if building a custom application that is interoperable with our existing architecture. We capitalized upon the migration of the publication metadata system to improve performance and reduce redundancy across other information resources, including a digital library, a publications content management system (CMS), and a research information system (RIS). With objectives toward standardization, openness, and cloud native environments, we modeled a Fedora-based metadata microservice that employs cloud-based environments for storing and indexing metadata, running Docker, and managing the continuous integration pipeline. 

--- a/_posts/2020-03-10-Maximizing-Productivity--Expediting-Metadata-Creation-and-Cleanup-for-Electronic-Theses-and-Dissertations-at-Oklahoma-State-University.md
+++ b/_posts/2020-03-10-Maximizing-Productivity--Expediting-Metadata-Creation-and-Cleanup-for-Electronic-Theses-and-Dissertations-at-Oklahoma-State-University.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Madison Chartier
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Maximizing Productivity&#58;  Expediting Metadata Creation and Cleanup for Electronic Theses and Dissertations at Oklahoma State University
+---
+Automated tasks and batch processes are integral components of successful, efficient metadata workflows.  Creating and cleaning metadata for user-submitted content, like electronic theses and dissertations (ETDs), can prove time-consuming and overwhelming small metadata teams.  At Oklahoma State University (OSU), Digital Resources and Discovery Services has expedited the metadata creation and cleanup process for ETDs by incorporating tools and software that automate batch processing into their workflow.  ProQuest’s UMI Dissertation Publishing helps stipulate required metadata fields upon content submission, producing consistently-tagged metadata as XML files.  Two XSLT transformations are run to sort out restricted submissions, extract select metadata from individual files, and merge this metadata into a single XML file.  This batch file is then uploaded to OpenRefine for mass editing and final formatting, before export as a .csv file.  Manual effort of the metadata team is whittled down to verifying accuracy and completeness of metadata before upload to the institutional repository.  This presentation will illustrate the success and efficiency this combination of tools and software has brought the OSU metadata team by producing good quality metadata in minimal time.

--- a/_posts/2020-03-10-NewspaperWorks-Its-How-Samvera-Does-Newspapers.md
+++ b/_posts/2020-03-10-NewspaperWorks-Its-How-Samvera-Does-Newspapers.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Eben English, Boston Public Library
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: NewspaperWorks&#58; It's How Samvera Does Newspapers
+---
+NewspaperWorks is a plugin for Samvera and Hyrax-based repository applications that provides custom ingest, management, and display functionality for digitized newspaper content. NewspaperWorks can be used to add newspapers to an existing repository, or to create a stand-alone bespoke newspaper content interface. This poster outlines the major features of this Rails engine, including automated ingest of NDNP batches and PDF issues; newspaper-specific metadata modules; full-text search and highlighting; calendar-based browsing; advanced search, and more.

--- a/_posts/2020-03-10-Open-Data-Barriers-that-Persist-at-the-Institutional-Level.md
+++ b/_posts/2020-03-10-Open-Data-Barriers-that-Persist-at-the-Institutional-Level.md
@@ -1,0 +1,13 @@
+---
+speakers-text: Ian Pollock, Data Services Specialist, Institute for Health Metrics and Evaluation – University of Washington; polloi@uw.edu. Yesenia Roman, Data Services Specialist, Institute for Health Metrics and Evaluation – University of Washington; yesenr2@uw.edu. Erica Leigh Slepak, Senior Data Services Specialist, Institute for Health Metrics and Evaluation – University of Washington; elnel@uw.edu.
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Open Data Barriers that Persist at the Institutional Level
+---
+The Institute for Health Metrics and Evaluation at The University of Washington is a large academic research institution where many different people contribute to large-scale research projects on a global scale. As librarians responsible for data acquisitions for an Institute – not just individual users - we face a range of barriers to accessing data, even datasets with clear paths to acquisition. These barriers can persist on either side of the acquisition process at such an institution.
+
+This poster will present some ‘pain points’ that are common to the data acquisitions experience at IHME, as well as proposals for improving data access by institutional users. We hope these proposals can help both data providers and institutional data users to help make the process easier on both sides.

--- a/_posts/2020-03-10-Parting-the-Metadata-Sea-a-Migration-to-Preserve-Religious-Sound.md
+++ b/_posts/2020-03-10-Parting-the-Metadata-Sea-a-Migration-to-Preserve-Religious-Sound.md
@@ -1,0 +1,13 @@
+---
+speakers-text: Kate Topham
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Parting the Metadata Sea&#58; a Migration to Preserve Religious Sound
+---
+The American Religious Sounds Project, a joint effort from Michigan State University and Ohio State University, has been gathering sound recordings of American religious life since 2014. The project is undertaking a dual process of expanding to other institutions and ingesting the collection into the Vincent Voice Library at MSU.
+With thousands of recordings, but scant metadata, it became clear that the collection could not endure this transformation without serious changes: The metadata schemas changed structure as the project evolved. The metadata itself was never updated and lacked vital preservation and administrative information. Files often got lost in the process of writing description and publishing to the web. However, this restructuring provided an opportunity to re-frame this digital humanities collection as an archive, incorporating preservation into existing workflows while streamlining the ingest and review process. We designed a new metadata schema to serve our growing community of stakeholders and built a custom application to streamline the collection and assessment of sound recordings and metadata and export materials to ingest into the Vincent Voice Library.
+This poster documents innovative techniques for cleaning, crosswalking, and re-constructing metadata as well as the broader process of collaborating across institutions, departments, and disciplines. 

--- a/_posts/2020-03-10-Pythagoras-Using-Python-to-Find-Patterns-in-Music-Score-Data.md
+++ b/_posts/2020-03-10-Pythagoras-Using-Python-to-Find-Patterns-in-Music-Score-Data.md
@@ -1,0 +1,15 @@
+---
+speakers-text: Brandon Bellanti, Simmons University
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Pythagoras&#58; Using Python to Find Patterns in Music Score Data
+---
+Pythagoras is an ongoing digital humanities project using Python to parse and analyze music scores encoded as MusicXML files. The primary goal of the project is to identify relationships within individual works, among works by the same composer, and among works from different composers.
+
+First, a score is converted from XML to a CSV then loaded into to a Pandas data frame where it can be analyzed. Simple analyses of scores include the distributions of pitches, note lengths, and instruments. More complex analyses include regex searches to find recurring patterns of notes. The results are stored in a database, visualized using Matplotlib and Tableau, and accessed through a web interface. When a user searches for a composer or work, any works or composers that utilize similar compositional styles or patterns are returned.
+
+An intended outcome for this project is to give music performers, educators, historians, librarians, and anyone else interested in digital humanities new insights into musical relationships as well as new methods of data analysis in the arts.  

--- a/_posts/2020-03-10-Surviving-a-postdeveloper-wasteland.md
+++ b/_posts/2020-03-10-Surviving-a-postdeveloper-wasteland.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Jason Fleming, Laura McBrayer
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Surviving a post-developer wasteland
+---
+When the entire web application development team of 2 left UNCW Randall Library’s IT department at the same time to pursue employment in the corporate world, we were faced with the dilemma of how to support a complex and recently expanded set of technologies. These included 50+ applications and websites, a newly created Docker/Rancher containerization structure and gitlab versioning workflow to manage. This poster illustrates how we maintained continuity of business through intensive cross training, planning, and building on the culture of documentation that our department already had in place.

--- a/_posts/2020-03-10-Testing-the-Usability-Scalability--Accessibility-of-a-SmallScale-Application-.md
+++ b/_posts/2020-03-10-Testing-the-Usability-Scalability--Accessibility-of-a-SmallScale-Application-.md
@@ -1,0 +1,11 @@
+---
+speakers-text: A. M. Serrano
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Testing the Usability, Scalability, & Accessibility of a Small-Scale Application 
+---
+Numerous library Software as a Service (SaaS) vendors have developed products with API access to facilitate data views and data management. Subsequently, the vendor customers working with this API data create graphical user interface (GUI) applications for ease of use by non-coders. This poster will document through the use of a flowchart the process of creating a derivative application for a single institution’s needs, scaling the application for outside institutions' use, and conducting user testing for the application and the application’s deployment materials. Successes, wrong turns, and failures in attempts to meet accessibility, usability, and scalability goals will be revealed. The resulting product is a scalable application posted on GitHub that includes deployment learning modules for non-coders. 

--- a/_posts/2020-03-10-The-application-of-machine-learning-technique-at-an-academic-library-a-python-example.md
+++ b/_posts/2020-03-10-The-application-of-machine-learning-technique-at-an-academic-library-a-python-example.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Yongming Wang
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: The application of machine learning technique at an academic library&#58; a python example
+---
+This poster will present the pilot project of using classification method, a machine learning (ML) technique, to categorize the vast amount of data of the library’s virtual reference transcripts. Two classification models, random forest model and gradient boosting model, were explored to classify the chat questions into two categories: reference questions and non-reference questions. The purpose of the project is to explore the possibility of using the classification model to automatically categorize the future new questions so that the library may better use its resources and serve the library users more effectively and efficiently.  General steps of ML and snippets of python code will also be presented.

--- a/_posts/2020-03-10-There-and-Back-Again-Or-how-to-pave-your-way-to-the-Library-of-the-Future-and-still-honor-your-past.md
+++ b/_posts/2020-03-10-There-and-Back-Again-Or-how-to-pave-your-way-to-the-Library-of-the-Future-and-still-honor-your-past.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Stefanie Maclin-Hurd
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: There, and Back Again&#58; Or, how to pave your way to the Library of the Future, and still honor your past
+---
+From Academic to Corporate to Public, these areas are all hiring librarians.  But in a world where IT, librarianship, and research are intersecting more and more, how much people in these roles adapt?  How must libraries?

--- a/_posts/2020-03-10-UsinUsing-XQuery-for-Metadata-Transformations.md
+++ b/_posts/2020-03-10-UsinUsing-XQuery-for-Metadata-Transformations.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Sarah Swanz, Librarian for Digital Media & Publishing, Vanderbilt University; Jim Duran, Director of the Vanderbilt Television News Archive, Vanderbilt University; Nathan Jones, Manager Digital Imaging Laboratory, Archivist, Vanderbilt University
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: Using XQuery for Metadata Transformations
+---
+The Vanderbilt Television New Archives, Jean and Alexander Heard Libraries, includes over 80,000 news programs from 1968 to present, described in 1.1 million news story records. The relational database is bulky, messy, and unsustainable for long-term preservation. The goal of this project was to migrate the records first written in multiple, home-grown metadata schemas into a single metadata schema -- PBCore, an audiovisual metadata standard originating with public broadcasters. Our team utilized the XQuery tool BaseX and developed a script that parsed the records into groupings of episodic records. We chose the XQuery programing language, despite our unfamiliarity with the technology to support our student and faculty needs for XQuery. While the XQuery language was more difficult for us than Python or JavaScript or an XSLT transform, we feel this project improved our team’s ability to provide instructional assistance with a language used in digital humanities and other disciplines. By migrating to a standard metadata schema in XML we are already reaping the rewards. We are sharing sample XML files with vendors to demo and test new content management systems.

--- a/_posts/2020-03-10-Whats-a-Microfilm-Proper-Digital-Archiving-for-Theses-and-Dissertations.md
+++ b/_posts/2020-03-10-Whats-a-Microfilm-Proper-Digital-Archiving-for-Theses-and-Dissertations.md
@@ -1,0 +1,11 @@
+---
+speakers-text: Emily Boss, Head of Metadata and Cataloging, University of Nevada, Reno
+type: poster
+length: 30
+day: 2
+categories: posters
+layout: presentation
+startTime: 2020-03-10 15:20
+title: What's a Microfilm? Proper Digital Archiving for Theses and Dissertations
+---
+Many universities still rely on paper or microfilming of theses and dissertations as a record of scholarly output despite the challenges that brings with embargoes and the capture of additional media types such as data sets, time-lapse photography, etc. Even with a properly proportioned institutional repository, are these unique files properly preserved and described? In this case study, one university attempts to tackle those issues and rid themselves of the burden of paper-pushing and microfilming towards a fully digital workflow for proper preservation of these unique materials. 


### PR DESCRIPTION
This adds posters from a spreadsheet that was shared with me. A few may be subject to change/removal but we can deal with that later. To test:

- visit the day 2 schedule, find the posters link at 3:20pm
- view the posters index, test a few of them

The speakers text on these is freeform and sometimes includes institutions, positions, parentheticals. I don't think it's worth our time to clean it up and I think poster session speakers should be able to display their affiliations too so I'm fine with it.
Also, we don't know the location of the poster session yet but it can be bulk added to all the posts when we do.